### PR TITLE
Removing hardcoded shape and depth map factor parameters from PlaneExtractor.h file

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -264,7 +264,7 @@ namespace Planar_SLAM
         // Assign keypoints to the grid for speed up feature matching (called in the constructor).
         void AssignFeaturesToGrid();
 
-        void ComputePlanes(const cv::Mat &imDepth, const cv::Mat &depth, const cv::Mat &imGrey, cv::Mat K);
+        void ComputePlanes(const cv::Mat &imDepth, const cv::Mat &depth, const cv::Mat &imGrey, cv::Mat K, float depthMapFactor);
     };
 
 }// namespace Planar_SLAM

--- a/include/PlaneExtractor.h
+++ b/include/PlaneExtractor.h
@@ -11,11 +11,6 @@
 
 typedef Eigen::Vector3d VertexType;
 
-const int kScaleFactor = 5000;
-
-const int kDepthWidth = 640;
-const int kDepthHeight = 480;
-
 #ifdef __linux__
 #define _isnan(x) isnan(x)
 #endif
@@ -54,9 +49,9 @@ public:
 
 	bool readColorImage(cv::Mat RGBImg);
 
-	bool readDepthImage(cv::Mat depthImg, cv::Mat &K);
+	bool readDepthImage(cv::Mat depthImg, cv::Mat &K, float kScaleFactor);
 
-	void runPlaneDetection();
+	void runPlaneDetection(int kDepthHeight, int kDepthWidth);
 
 };
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -89,7 +89,7 @@ namespace Planar_SLAM {
         std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
         thread threadLines(&Planar_SLAM::Frame::ExtractLSD, this, imGray, depth, tmpK);
         thread threadPoints(&Planar_SLAM::Frame::ExtractORB, this, 0, imGray);
-        thread threadPlanes(&Planar_SLAM::Frame::ComputePlanes, this, depth, imDepth, imRGB, K);
+        thread threadPlanes(&Planar_SLAM::Frame::ComputePlanes, this, depth, imDepth, imRGB, K, depthMapFactor);
         threadPoints.join();
         threadLines.join();
         threadPlanes.join();
@@ -644,10 +644,10 @@ namespace Planar_SLAM {
         return Lines3D;
     }
 
-    void Frame::ComputePlanes(const cv::Mat &imDepth, const cv::Mat &Depth, const cv::Mat &imRGB, cv::Mat K) {
+    void Frame::ComputePlanes(const cv::Mat &imDepth, const cv::Mat &Depth, const cv::Mat &imRGB, cv::Mat K, float depthMapFactor) {
         planeDetector.readColorImage(imRGB);
-        planeDetector.readDepthImage(Depth, K);
-        planeDetector.runPlaneDetection();
+        planeDetector.readDepthImage(Depth, K, depthMapFactor);
+        planeDetector.runPlaneDetection(imDepth.rows, imDepth.cols);
 
         for (int i = 0; i < planeDetector.plane_num_; i++) {
             auto &indices = planeDetector.plane_vertices_[i];

--- a/src/PlaneExtractor.cpp
+++ b/src/PlaneExtractor.cpp
@@ -3,12 +3,7 @@ using namespace std;
 using namespace cv;
 using namespace Eigen;
 
-PlaneDetection::PlaneDetection()
-{
-	cloud.vertices.resize(kDepthHeight * kDepthWidth);
-	cloud.w = kDepthWidth;
-	cloud.h = kDepthHeight;
-}
+PlaneDetection::PlaneDetection() { }
 
 PlaneDetection::~PlaneDetection()
 {
@@ -28,8 +23,13 @@ bool PlaneDetection::readColorImage(cv::Mat RGBImg)
 	return true;
 }
 
-bool PlaneDetection::readDepthImage(cv::Mat depthImg, cv::Mat &K)
+bool PlaneDetection::readDepthImage(cv::Mat depthImg, cv::Mat &K, float kScaleFactor)
 {
+    auto width = depthImg.cols;
+    auto height = depthImg.rows;
+    cloud.vertices.resize(height * width);
+    cloud.w = width;
+    cloud.h = height;
 	cv::Mat depth_img = depthImg;
 	if (depth_img.empty() || depth_img.depth() != CV_16U)
 	{
@@ -42,7 +42,7 @@ bool PlaneDetection::readDepthImage(cv::Mat depthImg, cv::Mat &K)
 	{
 		for (int j = 0; j < cols; j+=1)
 		{
-			double z = (double)(depth_img.at<unsigned short>(i, j)) / kScaleFactor;
+			double z = (double)(depth_img.at<unsigned short>(i, j)) * kScaleFactor;
 			if (_isnan(z))
 			{
 				cloud.vertices[vertex_idx++] = VertexType(0, 0, z);
@@ -56,7 +56,7 @@ bool PlaneDetection::readDepthImage(cv::Mat depthImg, cv::Mat &K)
 	return true;
 }
 
-void PlaneDetection::runPlaneDetection()
+void PlaneDetection::runPlaneDetection(int kDepthHeight, int kDepthWidth)
 {
 	seg_img_ = cv::Mat(kDepthHeight, kDepthWidth, CV_8UC3);
 	plane_filter.run(&cloud, &plane_vertices_, &seg_img_);


### PR DESCRIPTION
Now parameters such as image size and depth map factor are hardcoded in the PlaneExtractor.h file. This causes an error when trying to run program with images that do not match these parameters.

This PR contains the necessary fixes for reading shape and depth map factor from the config file.

It is important to mention that in [PlaneExtractor.cpp:45](https://github.com/vnmsklnk/PlanarSLAM/blob/bdded7ac8adacc41e0f57f0e230763427488c00a/src/PlaneExtractor.cpp#L45) the division sign was replaced with the multiplication sign, since [the inverse element is taken](https://github.com/vnmsklnk/PlanarSLAM/blob/af2a36baeeed5700619062ab1c279296f843fd1a/src/Tracking.cc#L122) from config file.